### PR TITLE
Fix when first render step 2 of dependencies, select by default first metadata type in selector

### DIFF
--- a/src/webapp/pages/bulk-apply/steps/ListDependenciesStep.tsx
+++ b/src/webapp/pages/bulk-apply/steps/ListDependenciesStep.tsx
@@ -181,7 +181,8 @@ export const ListDependenciesStep: React.FC<MetadataSharingWizardStepProps> = ({
                 setRows(rows);
                 setFilterOptions(filterModels);
                 setListOptions(options => ({ ...options, model: filterModels[0]?.id ?? "dashboards" }));
-                setFilteredRows(rows.filter(row => row.metadataType === selectedModel ?? filterModels[0]?.id));
+                setFilteredRows(rows.filter(row => row.metadataType === (selectedModel ?? filterModels[0]?.id)));
+
                 setIsLoading(false);
             },
             error => snackbar.error(error)


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #?

### :memo: Implementation
- Fix when first render step 2 of dependencies, select by default first metadata type in selector

### :art: Screenshots

### :fire: Testing
- Go to step 2 and see that it's selecting default metadata type in the selector
