### PR TITLE
use default app namespace

### DIFF
--- a/i18n/es.po
+++ b/i18n/es.po
@@ -123,7 +123,7 @@ msgid "No"
 msgstr ""
 
 msgid "Bulk apply sharing settings"
-msgstr ""
+msgstr "Aplicar configuración de uso compartido en masa"
 
 msgid "Select Metadata"
 msgstr ""

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1,4 +1,5 @@
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, namespace?: object): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }

--- a/src/webapp/contexts/app-context.ts
+++ b/src/webapp/contexts/app-context.ts
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { CompositionRoot } from "../../CompositionRoot";
 import { User } from "../../domain/entities/User";
 import { D2Api } from "../../types/d2-api";
+import i18n from "../../locales";
 
 export interface AppContextState {
     api: D2Api;
@@ -13,6 +14,7 @@ export const AppContext = React.createContext<AppContextState | null>(null);
 
 export function useAppContext() {
     const context = useContext(AppContext);
+    i18n.setDefaultNamespace("sharing-settings-app");
     if (context) {
         return context;
     } else {

--- a/src/webapp/pages/app/App.tsx
+++ b/src/webapp/pages/app/App.tsx
@@ -9,13 +9,13 @@ import { appConfig } from "../../../app-config";
 import { getCompositionRoot } from "../../../CompositionRoot";
 import { Instance } from "../../../data/entities/Instance";
 import { D2Api } from "../../../types/d2-api";
+import { Feedback } from "@eyeseetea/feedback-component";
 import Share from "../../components/share/Share";
 import { AppContext, AppContextState } from "../../contexts/app-context";
 import { Router } from "../Router";
 import "./App.css";
 import muiThemeLegacy from "./themes/dhis2-legacy.theme";
 import { muiTheme } from "./themes/dhis2.theme";
-import { Feedback } from "@eyeseetea/feedback-component";
 
 export interface AppProps {
     api: D2Api;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694ubx3x

### :memo: Implementation
- [x] Update i18n types
- [x] Set default namespace in `app-context.ts`

### :art: Screenshots
<img width="1080" alt="Screenshot 2024-06-25 at 16 05 41" src="https://github.com/EyeSeeTea/sharing-settings-app-dev/assets/37223065/e6b88717-fba8-4937-91ff-fcb92af9df0e">


### :fire: Testing
I added a translation for `Bulk apply sharing settings` to test

#8694ubx3x