### PR TITLE
[fix]: Show metadata dependencies for additional metadata types

### DIFF
--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -98,7 +98,8 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         switch (model) {
             case "dataElementGroupSets":
                 return this.getDataElementGroupSetWithDependencies(id);
-
+            case "organisationUnitGroups":
+                return this.getOrgUnitGroupDependencies(id);
             case "organisationUnitGroupSets":
                 return this.getOrgUnitGroupSetWithDependencies(id);
             default:
@@ -123,6 +124,27 @@ export class MetadataD2ApiRepository implements MetadataRepository {
             return Future.success({
                 dataElementGroups: dataElementGroups,
                 dataElementGroupSets: [rest],
+            });
+        });
+    }
+
+    private getOrgUnitGroupDependencies(id: string): FutureData<MetadataPayload> {
+        return apiToFuture(
+            this.api.models.organisationUnitGroups.get({
+                fields: {
+                    $owner: true,
+                    organisationUnits: { $owner: true },
+                },
+                filter: { id: { eq: id } },
+            })
+        ).flatMap(response => {
+            const d2Object = response.objects[0];
+            if (!d2Object) return Future.success({});
+
+            const { organisationUnits, ...rest } = d2Object;
+            return Future.success({
+                organisationUnits: organisationUnits,
+                organisationUnitGroups: [rest],
             });
         });
     }

--- a/src/domain/entities/MetadataItem.ts
+++ b/src/domain/entities/MetadataItem.ts
@@ -83,7 +83,15 @@ export type CodedRef = NamedRef & { code: string | undefined };
 export type MetadataItem = CodedRef & Sharing & SharedObject & { [key: string]: any | undefined };
 
 export function isValidModel(model: string): model is MetadataModel {
-    return ["dataSets", "programs", "dashboards"].includes(model);
+    return [
+        "dataSets",
+        "programs",
+        "dashboards",
+        "dataElementGroups",
+        "dataElementGroupSets",
+        "organisationUnitGroups",
+        "organisationUnitGroupSets",
+    ].includes(model);
 }
 
 export function isValidMetadataItem(item: any): item is MetadataItem {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8697g166u

### :memo: Implementation
- [x] Include `dataElementGroups`, `dataElementGroupSets`, `organisationUnitGroups` and `organisationUnitGroupSets` as valid models
- [x] Fetch dependencies for orgUnit and dataElement group sets

### :art: Screenshots
https://github.com/user-attachments/assets/9cace753-cf60-44a2-ad58-640c06f39e68

https://github.com/user-attachments/assets/7cbce8e5-afb3-4983-95e0-7b4045b22675

https://github.com/user-attachments/assets/cec01a0d-1044-4669-a2dc-2f0fc8eee0aa

### :fire: Testing



#8697g166u