### PR TITLE
fix: chunk ids in fetchMetadata

### DIFF
--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -79,7 +79,7 @@ export class MetadataD2ApiRepository implements MetadataRepository {
     }
 
     public getModelName(model: string): string {
-        return this.api.models[resolveModelAlias(model)].schema.displayName ?? i18n.t("Unknown model");
+        return this.api.models[model as ModelIndex]?.schema?.displayName ?? i18n.t("Unknown model");
     }
 
     public isShareable(model: string): boolean {

--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -79,15 +79,15 @@ export class MetadataD2ApiRepository implements MetadataRepository {
     }
 
     public getModelName(model: string): string {
-        return this.api.models[model as ModelIndex].schema.displayName ?? i18n.t("Unknown model");
+        return this.api.models[resolveModelAlias(model)].schema.displayName ?? i18n.t("Unknown model");
     }
 
     public isShareable(model: string): boolean {
-        return this.api.models[model as ModelIndex].schema.shareable ?? false;
+        return this.api.models[resolveModelAlias(model)].schema.shareable ?? false;
     }
 
     public isDataShareable(model: string): boolean {
-        return this.api.models[model as ModelIndex].schema.dataShareable ?? false;
+        return this.api.models[resolveModelAlias(model)].schema.dataShareable ?? false;
     }
 
     private _fetchMetadata(ids: string[]): FutureData<MetadataPayload> {
@@ -261,3 +261,8 @@ function getClassName(className: string): string | undefined {
 }
 
 type ModelIndex = keyof D2ApiDefinition["schemas"];
+
+// We don't have eventVisualization in d2-api, use similar eventReports
+function resolveModelAlias(model: string): ModelIndex {
+    return (model === "eventVisualizations" ? "eventReports" : model) as ModelIndex;
+}

--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -94,7 +94,7 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         return apiToFuture(this.api.get("/metadata", { filter: `id:in:[${ids.join(",")}]` }));
     }
 
-    private fetchMetadata(ids: string[], chunkSize = 500): FutureData<MetadataPayload> {
+    private fetchMetadata(ids: string[], chunkSize = 250): FutureData<MetadataPayload> {
         const $metadataRequests = _(ids)
             .chunk(chunkSize)
             .map(chunkIds => this._fetchMetadata(chunkIds))

--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -79,15 +79,15 @@ export class MetadataD2ApiRepository implements MetadataRepository {
     }
 
     public getModelName(model: string): string {
-        return this.api.models[model as ModelIndex]?.schema?.displayName ?? i18n.t("Unknown model");
+        return this.api.models[model as ModelIndex]?.schema.displayName ?? i18n.t("Unknown model");
     }
 
     public isShareable(model: string): boolean {
-        return this.api.models[resolveModelAlias(model)].schema.shareable ?? false;
+        return this.api.models[resolveModelAlias(model)]?.schema.shareable ?? false;
     }
 
     public isDataShareable(model: string): boolean {
-        return this.api.models[resolveModelAlias(model)].schema.dataShareable ?? false;
+        return this.api.models[resolveModelAlias(model)]?.schema.dataShareable ?? false;
     }
 
     private _fetchMetadata(ids: string[]): FutureData<MetadataPayload> {

--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -90,8 +90,17 @@ export class MetadataD2ApiRepository implements MetadataRepository {
         return this.api.models[model as ModelIndex].schema.dataShareable ?? false;
     }
 
-    private fetchMetadata(ids: string[]): FutureData<MetadataPayload> {
+    private _fetchMetadata(ids: string[]): FutureData<MetadataPayload> {
         return apiToFuture(this.api.get("/metadata", { filter: `id:in:[${ids.join(",")}]` }));
+    }
+
+    private fetchMetadata(ids: string[], chunkSize = 500): FutureData<MetadataPayload> {
+        const $metadataRequests = _(ids)
+            .chunk(chunkSize)
+            .map(chunkIds => this._fetchMetadata(chunkIds))
+            .value();
+
+        return Future.parallel($metadataRequests).map(responses => mergePayloads(responses));
     }
 
     private fetchMetadataWithDependencies(model: MetadataModel, id: string): FutureData<MetadataPayload> {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699qcfxn [Chaging sharing settings for 24 items fails with TypeError: Failed to fetch](https://app.clickup.com/t/8699qcfxn)

### :memo: Implementation
- chunk ids to avoid url too large
- resolve "eventVisualizations" to "eventReports" for isShareable and isDataShareable  
- fix default handing if model is not in `api.models`

### :art: Screenshots

https://github.com/user-attachments/assets/e2d5d4eb-4497-4969-afa3-0685a8bee2f7


### :fire: Testing
